### PR TITLE
Dynamic paths

### DIFF
--- a/helloled/src/main/java/com/solaborate/helloled/LedAnimation.java
+++ b/helloled/src/main/java/com/solaborate/helloled/LedAnimation.java
@@ -15,8 +15,14 @@ public class LedAnimation {
 
     private final String TAG = "LEDRing";
     private ByteBuffer mOutputBuffer = ByteBuffer.allocate(1024);//allocateDirect,allocate
+    private String writePath = "/dev/leds_3731";
 
-    public LedAnimation(){}
+    public LedAnimation() {
+    }
+
+    public LedAnimation(String writePath) {
+        this.writePath = writePath;
+    }
 
     /**
      * Writes colors in Hello LedRing
@@ -35,7 +41,7 @@ public class LedAnimation {
         try {
             mOutputBuffer.clear();
             mOutputBuffer.put(rgbData);
-            LedsFrameData.write(mOutputBuffer, rgbData.length);
+            LedsFrameData.write(mOutputBuffer, rgbData.length, writePath);
         } catch (IOException e) {
             Log.e(TAG, "write rgb data error:", e);
         }

--- a/helloled/src/main/java/com/solaborate/helloled/LedsFrameData.java
+++ b/helloled/src/main/java/com/solaborate/helloled/LedsFrameData.java
@@ -17,6 +17,6 @@ public class LedsFrameData {
 		}		
 
     }	
-	private static native void writeArray(byte[] buffer, int length,writePath) throws IOException;	//writeArray
-	private static native void writeDirect(ByteBuffer buffer, int length, writePath) throws IOException;	//writeDirect
+	private static native void writeArray(byte[] buffer, int length, String writePath) throws IOException;	//writeArray
+	private static native void writeDirect(ByteBuffer buffer, int length, String writePath) throws IOException;	//writeDirect
 }

--- a/helloled/src/main/java/com/solaborate/helloled/LedsFrameData.java
+++ b/helloled/src/main/java/com/solaborate/helloled/LedsFrameData.java
@@ -7,16 +7,16 @@ public class LedsFrameData {
 	static {
 		System.loadLibrary("LedsJNI");
 	}
-    static void write(ByteBuffer buffer, int length) throws IOException {
+    static void write(ByteBuffer buffer, int length, String writePath) throws IOException {
 		if (buffer.isDirect()) {
-			writeDirect(buffer, length);
+			writeDirect(buffer, length, writePath);
 		} else if (buffer.hasArray()) {
-			writeArray(buffer.array(), length);
+			writeArray(buffer.array(), length, writePath);
 		} else {
 			throw new IllegalArgumentException("buffer is not direct and has no array");
 		}		
 
     }	
-	private static native void writeArray(byte[] buffer, int length) throws IOException;	//writeArray
-	private static native void writeDirect(ByteBuffer buffer, int length) throws IOException;	//writeDirect
+	private static native void writeArray(byte[] buffer, int length,writePath) throws IOException;	//writeArray
+	private static native void writeDirect(ByteBuffer buffer, int length, writePath) throws IOException;	//writeDirect
 }

--- a/helloled/src/main/jni/leds/LedsJNI.cpp
+++ b/helloled/src/main/jni/leds/LedsJNI.cpp
@@ -8,7 +8,7 @@
 #include "LedsJNI.h"
 #include <stdlib.h> // pulls in declaration of malloc, free
 
-void Java_com_solaborate_helloled_LedsFrameData_writeArray(JNIEnv *env, jobject clazz, jbyteArray buffer, jint length)
+void Java_com_solaborate_helloled_LedsFrameData_writeArray(JNIEnv *env, jobject clazz, jbyteArray buffer, jint length, jstring path)
 {
     int fd, i;
     const char *filename = "/dev/leds_3731";
@@ -31,7 +31,7 @@ void Java_com_solaborate_helloled_LedsFrameData_writeArray(JNIEnv *env, jobject 
     close(fd);
 }
 
-void Java_com_solaborate_helloled_LedsFrameData_writeDirect(JNIEnv *env, jobject clazz, jobject buffer, jint length)
+void Java_com_solaborate_helloled_LedsFrameData_writeDirect(JNIEnv *env, jobject clazz, jobject buffer, jint length, jstring path)
 {
     int fd, i;
     const char *filename = "/dev/leds_3731";

--- a/helloled/src/main/jni/leds/LedsJNI.cpp
+++ b/helloled/src/main/jni/leds/LedsJNI.cpp
@@ -8,10 +8,10 @@
 #include "LedsJNI.h"
 #include <stdlib.h> // pulls in declaration of malloc, free
 
-void Java_com_solaborate_helloled_LedsFrameData_writeArray(JNIEnv *env, jobject clazz, jbyteArray buffer, jint length, jstring path)
+extern "C" void Java_com_solaborate_helloled_LedsFrameData_writeArray(JNIEnv *env, jclass clazz, jbyteArray buffer, jint length, jstring path)
 {
     int fd, i;
-    const char *filename = "/dev/leds_3731";
+    const char *filename = env->GetStringUTFChars(path, nullptr);
 
     fd = open(filename, O_WRONLY);
     if (fd < 0)
@@ -29,12 +29,13 @@ void Java_com_solaborate_helloled_LedsFrameData_writeArray(JNIEnv *env, jobject 
     jint ret = write(fd, buf, length);
     free(buf);
     close(fd);
+    env->ReleaseStringUTFChars(path, filename);
 }
 
-void Java_com_solaborate_helloled_LedsFrameData_writeDirect(JNIEnv *env, jobject clazz, jobject buffer, jint length, jstring path)
+extern "C" void Java_com_solaborate_helloled_LedsFrameData_writeDirect(JNIEnv *env, jclass clazz, jobject buffer, jint length, jstring path)
 {
     int fd, i;
-    const char *filename = "/dev/leds_3731";
+    const char *filename = env->GetStringUTFChars(path, nullptr);
 
     fd = open(filename, O_WRONLY);
     if (fd < 0)
@@ -50,4 +51,5 @@ void Java_com_solaborate_helloled_LedsFrameData_writeDirect(JNIEnv *env, jobject
     int ret = write(fd, buf, length);
     free(buf);
     close(fd);
+    env->ReleaseStringUTFChars(path, filename);
 }

--- a/helloled/src/main/jni/leds/LedsJNI.h
+++ b/helloled/src/main/jni/leds/LedsJNI.h
@@ -6,8 +6,8 @@
 extern "C" {
 #endif
 
-JNIEXPORT void JNICALL Java_com_solaborate_helloled_LedsFrameData_writeArray(JNIEnv *, jobject , jbyteArray, jint, jstring);
-JNIEXPORT void JNICALL Java_com_solaborate_helloled_LedsFrameData_writeDirect(JNIEnv *, jobject, jobject, jint, jstring);
+JNIEXPORT void JNICALL Java_com_solaborate_helloled_LedsFrameData_writeArray(JNIEnv *, jclass , jbyteArray, jint, jstring);
+JNIEXPORT void JNICALL Java_com_solaborate_helloled_LedsFrameData_writeDirect(JNIEnv *, jclass, jobject, jint, jstring);
 #ifdef __cplusplus
 }
 #endif

--- a/helloled/src/main/jni/leds/LedsJNI.h
+++ b/helloled/src/main/jni/leds/LedsJNI.h
@@ -6,8 +6,8 @@
 extern "C" {
 #endif
 
-JNIEXPORT void JNICALL Java_com_solaborate_helloled_LedsFrameData_writeArray(JNIEnv *, jobject , jbyteArray, jint);
-JNIEXPORT void JNICALL Java_com_solaborate_helloled_LedsFrameData_writeDirect(JNIEnv *, jobject, jobject, jint);
+JNIEXPORT void JNICALL Java_com_solaborate_helloled_LedsFrameData_writeArray(JNIEnv *, jobject , jbyteArray, jint, jstring);
+JNIEXPORT void JNICALL Java_com_solaborate_helloled_LedsFrameData_writeDirect(JNIEnv *, jobject, jobject, jint, jstring);
 #ifdef __cplusplus
 }
 #endif

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.solaborate.helloled.sample"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
     }
@@ -21,5 +21,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    implementation 'com.solaborate:helloled:1.0.0'
+//    implementation 'com.solaborate:helloled:1.0.0'
+    implementation project(':helloled')
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':sample', ':helloled'
+include ':sample'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':sample'
+include ':sample',":helloled"


### PR DESCRIPTION
Closes #4 

Overloaded the `LedAnimation` constructor to take a write path. This is really useful when we need to write for LED on different paths, updated the native code to reflect these changes too.

Moved the `sample` directory to use `helloled` as a module instead of the dependency because it's easier for development and goes more with the sample "purpose".